### PR TITLE
Port to seaborn 0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
         'numpy',
         'numpydoc',
         'pandas',
-        'seaborn==0.5.1',
+        'seaborn>=0.6',
         'sphinx',
         'tornado>=4.0',
     ],

--- a/src/plot_utils.py
+++ b/src/plot_utils.py
@@ -477,16 +477,11 @@ def do_violinplot(plot_df, vartypes, **kwargs):
     unique_vals = np.sort(unique_vals)
     n_vals = len(plot_df[groupby].unique())
 
-    if vert:
-        vals = plot_df.columns[1]
-    else:
-        vals = plot_df.columns[0]
-
     if dummy:
         sub_vals = np.sort(plot_df[groupby].unique())
         axis = sns.violinplot(
-            x=(groupby if vert else vals),
-            y=(vals if vert else groupby),
+            x=plot_df.columns[0],
+            y=plot_df.columns[1],
             data=NonZeroDWIMFrameWrapper(plot_df),
             order=sub_vals, hue=plot_df.columns[2],
             names=sub_vals, ax=ax, orient=("v" if vert else "h"),
@@ -494,8 +489,8 @@ def do_violinplot(plot_df, vartypes, **kwargs):
         axis.legend_ = None
     else:
         sns.violinplot(
-            x=(groupby if vert else vals),
-            y=(vals if vert else groupby),
+            x=plot_df.columns[0],
+            y=plot_df.columns[1],
             data=NonZeroDWIMFrameWrapper(plot_df),
             order=unique_vals, names=unique_vals, ax=ax,
             orient=("v" if vert else "h"),

--- a/src/plot_utils.py
+++ b/src/plot_utils.py
@@ -476,41 +476,30 @@ def do_violinplot(plot_df, vartypes, **kwargs):
 
     unique_vals = np.sort(unique_vals)
     n_vals = len(plot_df[groupby].unique())
-    if dummy:
-        order_key = dict((val, i) for i, val in enumerate(unique_vals))
-        base_width = 0.75/len(colors)
-        violin_width = base_width
-        for i, (val, color) in enumerate(colors.iteritems()):
-            subdf = plot_df.loc[plot_df.ix[:, 2] == val]
-            if subdf.empty:
-                continue
 
-            if vert:
-                vals = subdf.columns[1]
-            else:
-                vals = subdf.columns[0]
-
-            # not evey categorical value is guaranteed to appear in each subdf.
-            # Here we compensate.
-            sub_vals = np.sort(subdf[groupby].unique())
-            positions = []
-
-            for v in sub_vals:
-                positions.append(base_width*i + order_key[v] + base_width/2
-                                 - .75/2)
-
-            sns.violinplot(NonZeroDWIMSeriesWrapper(subdf[vals]),
-                           groupby=subdf[groupby], order=sub_vals,
-                names=sub_vals, vert=vert, ax=ax, positions=positions,
-                widths=violin_width, color=color)
+    if vert:
+        vals = plot_df.columns[1]
     else:
-        if vert:
-            vals = plot_df.columns[1]
-        else:
-            vals = plot_df.columns[0]
-        sns.violinplot(NonZeroDWIMSeriesWrapper(plot_df[vals]), groupby=plot_df[groupby],
-            order=unique_vals, names=unique_vals, vert=vert, ax=ax, positions=0,
-            color='SteelBlue')
+        vals = plot_df.columns[0]
+
+    if dummy:
+        sub_vals = np.sort(plot_df[groupby].unique())
+        axis = sns.violinplot(
+            x=(groupby if vert else vals),
+            y=(vals if vert else groupby),
+            data=NonZeroDWIMFrameWrapper(plot_df),
+            order=sub_vals, hue=plot_df.columns[2],
+            names=sub_vals, ax=ax, orient=("v" if vert else "h"),
+            palette=colors, inner='quartile')
+        axis.legend_ = None
+    else:
+        sns.violinplot(
+            x=(groupby if vert else vals),
+            y=(vals if vert else groupby),
+            data=NonZeroDWIMFrameWrapper(plot_df),
+            order=unique_vals, names=unique_vals, ax=ax,
+            orient=("v" if vert else "h"),
+            color='SteelBlue', inner='quartile')
 
     if vert:
         ax.set_xlim([-.5, n_vals-.5])

--- a/tests/plot_utils.py
+++ b/tests/plot_utils.py
@@ -77,5 +77,12 @@ def main():
              show_full=False)
     plt.savefig('fig1.png')
 
+    # again, to exercise the no-color-by code path
+    plt.figure(tight_layout=True, facecolor='white')
+    _pairplot(df, bdb=bdb, generator_name='plottest_cc',
+             use_shortname=False, show_contour=False,
+             show_full=False)
+    plt.savefig('fig2.png')
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
As far as I know, the only problem was that they rearranged to api of violin plots.

Testing strategy was visual assessment of the figures produced by tests/plot_utils.py (and tests/crosscat_utils.py, which was unaffected).  The figures render somewhat differently now, but I think the change is acceptable.