### PR TITLE
Unify the BQL strings capitalization and indentation for readability.

### DIFF
--- a/examples/satellites/Satellites.ipynb
+++ b/examples/satellites/Satellites.ipynb
@@ -1625,9 +1625,10 @@
    "source": [
     "q('''\n",
     "CREATE TEMP TABLE satellite_purpose AS\n",
-    "SIMULATE country_of_operator, purpose FROM satellites_cc\n",
-    "GIVEN Class_of_orbit = 'GEO', Dry_mass_kg = 500 \n",
-    "LIMIT 1000;\n",
+    "    SIMULATE country_of_operator, purpose\n",
+    "    FROM satellites_cc\n",
+    "        GIVEN Class_of_orbit = 'GEO', Dry_mass_kg = 500 \n",
+    "    LIMIT 1000;\n",
     "''');"
    ]
   },
@@ -1662,10 +1663,10 @@
    "source": [
     "bdbcontrib.barplot(satellites.bdb, '''\n",
     "SELECT country_of_operator || \"--\" || purpose AS \"Country-Purpose\", \n",
-    "COUNT(\"Country-Purpose\") AS frequency\n",
+    "    COUNT(\"Country-Purpose\") AS frequency\n",
     "FROM satellite_purpose\n",
-    "GROUP BY \"Country-Purpose\"\n",
-    "ORDER BY frequency DESC\n",
+    "    GROUP BY \"Country-Purpose\"\n",
+    "    ORDER BY frequency DESC\n",
     "LIMIT 20;\n",
     "''');"
    ]
@@ -1739,10 +1740,11 @@
     }
    ],
    "source": [
-    "q('''SELECT country_of_operator, purpose, Class_of_orbit, Dry_mass_kg\n",
-    "FROM satellites\n",
-    "WHERE Class_of_orbit = 'GEO'\n",
-    "AND Dry_Mass_kg BETWEEN 400 AND 600''')"
+    "q('''\n",
+    "SELECT country_of_operator, purpose, Class_of_orbit, Dry_mass_kg\n",
+    "    FROM satellites\n",
+    "        WHERE Class_of_orbit = 'GEO'\n",
+    "            AND Dry_Mass_kg BETWEEN 400 AND 600''')"
    ]
   },
   {
@@ -1910,10 +1912,11 @@
     }
    ],
    "source": [
-    "q('''SELECT country_of_operator, purpose, Class_of_orbit, Dry_mass_kg\n",
-    "FROM satellites\n",
-    "WHERE Class_of_orbit = 'GEO'\n",
-    "AND Dry_Mass_kg BETWEEN 300 AND 700''')"
+    "q('''\n",
+    "SELECT country_of_operator, purpose, Class_of_orbit, Dry_mass_kg\n",
+    "    FROM satellites\n",
+    "        WHERE Class_of_orbit = 'GEO'\n",
+    "            AND Dry_Mass_kg BETWEEN 300 AND 700''')"
    ]
   },
   {
@@ -1967,9 +1970,7 @@
     }
    ],
    "source": [
-    "bdbcontrib.heatmap(satellites.bdb,\n",
-    "                   '''ESTIMATE DEPENDENCE PROBABILITY\n",
-    "                   FROM PAIRWISE COLUMNS OF satellites_cc;''');"
+    "bdbcontrib.heatmap(satellites.bdb,'ESTIMATE DEPENDENCE PROBABILITY FROM PAIRWISE COLUMNS OF satellites_cc;');"
    ]
   },
   {
@@ -2001,7 +2002,6 @@
    ],
    "source": [
     "# WARNING: This may take a couple minutes.\n",
-    "\n",
     "bdbcontrib.heatmap(satellites.bdb, 'ESTIMATE CORRELATION FROM PAIRWISE COLUMNS OF satellites_cc;');"
    ]
   },
@@ -2129,12 +2129,12 @@
    "source": [
     "q('''\n",
     "CREATE TEMP TABLE inferred_orbit AS\n",
-    "INFER EXPLICIT\n",
-    "anticipated_lifetime, perigee_km, period_minutes, class_of_orbit,\n",
-    "PREDICT type_of_orbit AS inferred_orbit_type\n",
-    "CONFIDENCE inferred_orbit_type_conf\n",
-    "FROM satellites_cc\n",
-    "WHERE type_of_orbit IS NULL;\n",
+    "    INFER EXPLICIT anticipated_lifetime, perigee_km,\n",
+    "        period_minutes, class_of_orbit,\n",
+    "        PREDICT type_of_orbit AS inferred_orbit_type\n",
+    "            CONFIDENCE inferred_orbit_type_conf\n",
+    "    FROM satellites_cc\n",
+    "        WHERE type_of_orbit IS NULL;\n",
     "''')"
    ]
   },
@@ -2522,7 +2522,7 @@
     }
    ],
    "source": [
-    "q('SELECT * FROM inferred_orbit limit 30;')"
+    "q('SELECT * FROM inferred_orbit LIMIT 30;')"
    ]
   },
   {
@@ -2545,8 +2545,9 @@
    ],
    "source": [
     "bdbcontrib.pairplot(satellites.bdb,'''\n",
-    "SELECT inferred_orbit_type, inferred_orbit_type_conf, class_of_orbit FROM inferred_orbit;\n",
-    "''', colorby='class_of_orbit');"
+    "    SELECT inferred_orbit_type,\n",
+    "        inferred_orbit_type_conf, class_of_orbit\n",
+    "        FROM inferred_orbit;''', colorby='class_of_orbit');"
    ]
   },
   {
@@ -2625,9 +2626,11 @@
    ],
    "source": [
     "q('''\n",
-    "CREATE TEMP TABLE unlikely_periods AS ESTIMATE name, class_of_orbit, period_minutes,\n",
-    "PREDICTIVE PROBABILITY OF period_minutes AS \"Relative Probability of Period\"\n",
-    "FROM satellites_cc;\n",
+    "CREATE TEMP TABLE unlikely_periods AS\n",
+    "    ESTIMATE name, class_of_orbit, period_minutes,\n",
+    "        PREDICTIVE PROBABILITY OF period_minutes\n",
+    "            AS \"Relative Probability of Period\"\n",
+    "    FROM satellites_cc;\n",
     "''')"
    ]
   },
@@ -2772,8 +2775,9 @@
    "source": [
     "q('''\n",
     "SELECT * FROM unlikely_periods\n",
-    "WHERE class_of_orbit = 'GEO' AND period_minutes IS NOT NULL\n",
-    "ORDER BY \"Relative Probability of Period\" ASC LIMIT 10;\n",
+    "    WHERE class_of_orbit = 'GEO'\n",
+    "        AND period_minutes IS NOT NULL\n",
+    "    ORDER BY \"Relative Probability of Period\" ASC LIMIT 10;\n",
     "''')"
    ]
   },
@@ -2839,7 +2843,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "version": "2.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Non functional changes, ensures that
- SQL/BQL keywords are capitalized.
- Indentation tries to group statements together, for instance

ESTIMATE foo, bar, sax,
PREDICTIVE PROBABILITY OF baz FROM quux

can be stylized as

ESTIMATE foo, bar
	sax, PREDICTIVE PROBABILITY OF baz,
FROM quux

To emphasize that PREDICTIVE PROBABILITY OF baz is a model
estimator is "linked" to the ESTIMATE query, not something
that is seperate.