### PR TITLE
Unpin numpy/matplotlib/scipy and pin seaborn.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,12 +125,12 @@ setup(
         'bayeslite>=0.1.6',
         'ipython[notebook]>=3',
         'markdown2',
-        'matplotlib==1.4.3',  # See bdbcontrib/issues/94
-        'numpy==1.8.2',       # See bdbcontrib/issues/94
+        'matplotlib',
+        'numpy',
         'numpydoc',
         'pandas>=0.17.0',
-        'seaborn>=0.6',
-        'scipy==0.15.1',      # See bdbcontrib/issues/94
+        'seaborn>=0.7',  # seaborn 0.6 is at the root of #94.
+        'scipy',
         'sklearn',
         'sklearn-pandas',
         'sphinx',


### PR DESCRIPTION
@gregory-marton points out that seaborn 0.6 is really at the root of #94,
so pin seaborn to 0.7 or later.

Remove numpy, scipy, and matplotlib pins, because they make installation
much more tricky on systems with binary packages, and current versions
of them work fine.