### PR TITLE
Small improvements + documentation for parallel.py

### DIFF
--- a/doc/internal.rst
+++ b/doc/internal.rst
@@ -9,3 +9,4 @@ Internal BDB Contrib Components
     diagnostic
     shell
     crosscat
+    parallel

--- a/doc/parallel.rst
+++ b/doc/parallel.rst
@@ -1,0 +1,5 @@
+:mod:`bdbcontrib.parallel`: Parallelizing queries
+========================================================
+
+.. automodule:: bdbcontrib.parallel
+ :members:

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -16,7 +16,6 @@
 
 import bayeslite
 from bayeslite.exception import BayesLiteException as BLE
-import os
 import random
 import test_utils
 import tempfile
@@ -25,13 +24,12 @@ import pytest
 from bdbcontrib import cursor_to_df, parallel
 from apsw import SQLError
 
+
 def test_estimate_pairwise_similarity():
     """
     Tests basic estimate pairwise similarity functionality against
     existing BQL estimate queries.
     """
-    os.environ['BAYESDB_WIZARD_MODE'] = '1'
-
     with tempfile.NamedTemporaryFile(suffix='.bdb') as bdb_file:
         bdb = bayeslite.bayesdb_open(bdb_file.name)
         with tempfile.NamedTemporaryFile() as temp:
@@ -136,8 +134,6 @@ def test_estimate_pairwise_similarity_long():
     Tests larger queries that need to be broken into batch inserts of 500
     values each, as well as the N parameter.
     """
-    os.environ['BAYESDB_WIZARD_MODE'] = '1'
-
     with tempfile.NamedTemporaryFile(suffix='.bdb') as bdb_file:
         bdb = bayeslite.bayesdb_open(bdb_file.name)
         with tempfile.NamedTemporaryFile() as temp:


### PR DESCRIPTION
This adds

- Documentation (and a very brief performance example) for `parallel.py`
- Stylistic improvements mentioned by @riastradh-probcomp in #105.

Concerning [this comment](https://github.com/probcomp/bdbcontrib/pull/105#commitcomment-15808594) by riastradh about having worker processes insert into the bdb rather than collecting results in a queue to save memory: I was unable to immediately get this working. Replacing the insertion into the queue with an insertion into the bdb led to failed tests where some rows were missing from the computed similarity table. Likely there is some error in the way threading is being handled here.

```
            # test other values of N
            for N in [1, 2, 10, 20, 40]:
                parallel.estimate_pairwise_similarity(
                    bdb_file.name, 't', 't_cc', N=N, overwrite=True
                )
>               assert cursor_to_df(
                    bdb.execute('SELECT * FROM t_similarity')
                ).shape == (N**2, 3)
E               assert (1, 3) == (4, 3)
E                 At index 0 diff: 1 != 4
E                 Full diff:
E                 - (1, 3)
E                 ?  ^
E                 + (4, 3)
E                 ?  ^
This means that when estimating N^2=4 pairwise similarity scores from the table,
which should produce 4 corresponding rows in the similarity table, only 1 row was found.
```

It'll take me some time to get to the bottom of why this could be happening, but until then, I thought I'd share my work thus far.