### PR TITLE
Avoid gratuitous incompatibilities on Ubuntu 14.04.

### DIFF
--- a/hooks/hook_utils.py
+++ b/hooks/hook_utils.py
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import markdown2
+import markdown
 import os
 import shutil
 import shlex
@@ -67,7 +67,7 @@ def render_bql_as_html(self, argin):
     with open(bql_file) as f:
         mdstr = utils.mdread(f, output_dir, self)
 
-    html = head + markdown2.markdown(mdstr) + '</html>'
+    html = head + markdown.markdown(mdstr) + '</html>'
 
     htmlfilename = os.path.splitext(os.path.basename(bql_file))[0]
     htmlfilename = os.path.join(output_dir, htmlfilename + '.html')

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ setup(
     install_requires=[
         'bayeslite>=0.1.6',
         'ipython[notebook]>=3',
-        'markdown2',
+        'markdown',
         'matplotlib',
         'numpy',
         'numpydoc',

--- a/src/recipes.py
+++ b/src/recipes.py
@@ -44,15 +44,21 @@ def quick_explore_vars(self, varnames, plotfile=None, nsimilar=20):
     raise BLE(ValueError('Need to explore at least two variables.'))
   self.pairplot_vars(varnames)
   query_columns = '''"%s"''' % '''", "'''.join(varnames)
-  deps = self.query('''ESTIMATE DEPENDENCE PROBABILITY
-                       FROM PAIRWISE COLUMNS OF %s
-                       FOR %s;''' % (self.generator_name, query_columns))
-  deps.columns = ['genid', 'name0', 'name1', 'value']
+  with self.bdb.savepoint():
+    temptab = self.bdb.temp_table_name()
+    self.query('''
+      CREATE TEMP TABLE %s AS
+        ESTIMATE DEPENDENCE PROBABILITY
+          FROM PAIRWISE COLUMNS OF %s FOR %s
+    ''' % (temptab, self.generator_name, query_columns))
+    deps = self.query('SELECT * FROM %s' % (temptab,))
+    deps.columns = ['genid', 'name0', 'name1', 'value']
+    triangle = self.query('''
+      SELECT * FROM %s WHERE name0 < name1 ORDER BY value DESC
+    ''' % (temptab,))
+    triangle.columns = ['genid', 'name0', 'name1', 'value']
   if plotfile:
     self.logger.plot(plotfile + '-deps', self.heatmap(deps))
-  deps.columns = ['genid', 'name0', 'name1', 'value']
-  triangle = deps[deps['name0'] < deps['name1']]
-  triangle = triangle.sort_values(ascending=False, by=['value'])
   self.logger.result("Pairwise dependence probability for: %s\n%s\n\n",
                      query_columns, triangle)
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -91,11 +91,11 @@ def test_estimate_pairwise_similarity():
         )
 
         parallel_sim = cursor_to_df(
-            bdb.execute('SELECT * FROM t_similarity')
-        ).sort_values(by=['rowid0', 'rowid1'])
+            bdb.execute('SELECT * FROM t_similarity ORDER BY rowid0, rowid1')
+        )
         parallel_sim_2 = cursor_to_df(
-            bdb.execute('SELECT * FROM t_similarity_2')
-        ).sort_values(by=['rowid0', 'rowid1'])
+            bdb.execute('SELECT * FROM t_similarity_2 ORDER BY rowid0, rowid1')
+        )
 
         # Results may be returned out of order. So we sort the values,
         # as above, and we reorder the numeric index
@@ -178,8 +178,8 @@ def test_estimate_pairwise_similarity_long():
             )
 
         parallel_sim = cursor_to_df(
-            bdb.execute('SELECT * FROM t_similarity')
-        ).sort_values(by=['rowid0', 'rowid1'])
+            bdb.execute('SELECT * FROM t_similarity ORDER BY rowid0, rowid1')
+        )
         parallel_sim.index = range(parallel_sim.shape[0])
 
         std_sim = cursor_to_df(


### PR DESCRIPTION
This makes ./check.sh pass with the only additional package required from pypi being seaborn -- numpy, scipy, pandas, matplotlib, &c. from Ubuntu 14.04 all work.

This does not remove any functionality, nor do I expect it to create incompatibilities in newer versions.